### PR TITLE
🔧 MAINTAIN: Create module exports for internal classes

### DIFF
--- a/src/directives/admonitions.ts
+++ b/src/directives/admonitions.ts
@@ -62,46 +62,47 @@ class BaseAdmonition extends Directive {
   }
 }
 
-class Admonition extends BaseAdmonition {
+export class Admonition extends BaseAdmonition {
   public required_arguments = 1
 }
 
-class Attention extends BaseAdmonition {
+export class Attention extends BaseAdmonition {
   public title = "Attention"
 }
 
-class Caution extends BaseAdmonition {
+export class Caution extends BaseAdmonition {
   public title = "Caution"
 }
 
-class Danger extends BaseAdmonition {
+export class Danger extends BaseAdmonition {
   public title = "Danger"
 }
 
-class Error extends BaseAdmonition {
+export class Error extends BaseAdmonition {
   public title = "Error"
 }
 
-class Important extends BaseAdmonition {
+export class Important extends BaseAdmonition {
   public title = "Important"
 }
 
-class Hint extends BaseAdmonition {
+export class Hint extends BaseAdmonition {
   public title = "Hint"
 }
-class Note extends BaseAdmonition {
+
+export class Note extends BaseAdmonition {
   public title = "Note"
 }
 
-class SeeAlso extends BaseAdmonition {
+export class SeeAlso extends BaseAdmonition {
   public title = "See Also"
 }
 
-class Tip extends BaseAdmonition {
+export class Tip extends BaseAdmonition {
   public title = "Tip"
 }
 
-class Warning extends BaseAdmonition {
+export class Warning extends BaseAdmonition {
   public title = "Warning"
 }
 

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -1,0 +1,17 @@
+export { Directive } from "./main"
+export { default as directivePlugin } from "./plugin"
+export type { IOptions as IDirectiveOptions } from "./types"
+
+export { admonitions } from "./admonitions"
+export { code } from "./code"
+export { images } from "./images"
+export { tables } from "./tables"
+export { math } from "./math"
+
+import { admonitions } from "./admonitions"
+import { code } from "./code"
+import { images } from "./images"
+import { tables } from "./tables"
+import { math } from "./math"
+
+export const directives = { ...admonitions, ...images, ...code, ...tables, ...math }

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -14,4 +14,10 @@ import { images } from "./images"
 import { tables } from "./tables"
 import { math } from "./math"
 
-export const directives = { ...admonitions, ...images, ...code, ...tables, ...math }
+export const directivesDefault = {
+  ...admonitions,
+  ...images,
+  ...code,
+  ...tables,
+  ...math
+}

--- a/src/directives/plugin.ts
+++ b/src/directives/plugin.ts
@@ -5,7 +5,7 @@ import { IOptions } from "./types"
 
 export default function directivePlugin(md: MarkdownIt, options: IOptions): void {
   let after = options.directivesAfter || "block"
-  if (options.replaceFences) {
+  if (options.replaceFences ?? true) {
     md.core.ruler.after(after, "fence_to_directive", replaceFences)
     after = "fence_to_directive"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,8 @@
 import type MarkdownIt from "markdown-it/lib"
-import { admonitions } from "./directives/admonitions"
-import { code } from "./directives/code"
-import { images } from "./directives/images"
-import directivePlugin from "./directives/plugin"
-import type { IOptions as IDirectiveOptions } from "./directives/types"
-import { tables } from "./directives/tables"
-import { roles } from "./roles/main"
-import { html } from "./roles/html"
-import rolePlugin from "./roles/plugin"
-import type { IOptions as IRoleOptions } from "./roles/types"
-import { math as mathRole } from "./roles/math"
-import { math as mathDirective } from "./directives/math"
+import { directives, Directive, directivePlugin, IDirectiveOptions } from "./directives"
+import { roles, Role, rolePlugin, IRoleOptions } from "./roles"
+
+export { directives, directivePlugin, Directive, roles, rolePlugin, Role }
 
 /** Allowed options for docutils plugin */
 export interface IOptions extends IDirectiveOptions, IRoleOptions {
@@ -23,8 +15,8 @@ const OptionDefaults: IOptions = {
   replaceFences: true,
   rolesAfter: "inline",
   directivesAfter: "block",
-  directives: { ...admonitions, ...images, ...code, ...tables, ...mathDirective },
-  roles: { ...roles, ...html, ...mathRole }
+  directives,
+  roles
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,14 @@
 import type MarkdownIt from "markdown-it/lib"
-import { directives, Directive, directivePlugin, IDirectiveOptions } from "./directives"
-import { roles, Role, rolePlugin, IRoleOptions } from "./roles"
+import { rolesDefault, Role, rolePlugin, IRoleOptions } from "./roles"
+import {
+  directivesDefault,
+  Directive,
+  directivePlugin,
+  IDirectiveOptions
+} from "./directives"
 
-export { directives, directivePlugin, Directive, roles, rolePlugin, Role }
+export { rolesDefault, rolePlugin, Role }
+export { directivesDefault, directivePlugin, Directive }
 
 /** Allowed options for docutils plugin */
 export interface IOptions extends IDirectiveOptions, IRoleOptions {
@@ -15,8 +21,8 @@ const OptionDefaults: IOptions = {
   replaceFences: true,
   rolesAfter: "inline",
   directivesAfter: "block",
-  directives,
-  roles
+  directives: directivesDefault,
+  roles: rolesDefault
 }
 
 /**

--- a/src/roles/index.ts
+++ b/src/roles/index.ts
@@ -7,4 +7,4 @@ import { main } from "./main"
 import { math } from "./math"
 import { html } from "./html"
 
-export const roles = { ...main, ...html, ...math }
+export const rolesDefault = { ...main, ...html, ...math }

--- a/src/roles/index.ts
+++ b/src/roles/index.ts
@@ -1,0 +1,10 @@
+export { Role, main } from "./main"
+export { default as rolePlugin } from "./plugin"
+export type { IOptions as IRoleOptions } from "./types"
+export { math } from "./math"
+
+import { main } from "./main"
+import { math } from "./math"
+import { html } from "./html"
+
+export const roles = { ...main, ...html, ...math }

--- a/src/roles/main.ts
+++ b/src/roles/main.ts
@@ -35,6 +35,6 @@ export class RawRole extends Role {
   }
 }
 
-export const roles = {
+export const main = {
   raw: RawRole
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,7 +44,7 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",                     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
Allows creation of Directives and Roles externally.

This pushes the exports down into the various folders and exposes some of the classes to external packages. This is needed for other packages to create new roles/directives without knowing the internal structure of the library.