### PR TITLE
✨ NEW: Add math directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ All directives have a fallback renderer, but the the following are specifically 
 - Tables:
   - `list-table`
 - HTML:
- - `sub`: Subscript
- - `sup`: Superscript
- - `abbr`: Abbreviation
+  - `sub`: Subscript
+  - `sup`: Superscript
+  - `abbr`: Abbreviation
+- Other:
+  - `math` 
 
 ## CSS Styling
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -98,6 +98,13 @@ HTML:
 * H{sub}`2`O
 * 4{sup}`th` of July
 * {abbr}`CSS (Cascading Style Sheets)`
+          
+Math:
+          
+```{math}
+:label: math_label
+w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}    
+```
 </textarea
         >
         <div id="renderer" class="rendered"></div>

--- a/src/directives/admonitions.ts
+++ b/src/directives/admonitions.ts
@@ -18,7 +18,7 @@ class BaseAdmonition extends Directive {
     name: unchanged
   }
   public title = ""
-  run(data: IDirectiveData): Token[] {
+  run(data: IDirectiveData<keyof BaseAdmonition["option_spec"]>): Token[] {
     const newTokens: Token[] = []
 
     // we create an overall container, then individual containers for the title and body

--- a/src/directives/code.ts
+++ b/src/directives/code.ts
@@ -29,7 +29,7 @@ export class Code extends Directive {
     name: unchanged,
     class: class_option
   }
-  run(data: IDirectiveData): Token[] {
+  run(data: IDirectiveData<keyof Code["option_spec"]>): Token[] {
     // TODO handle options
     this.assert_has_content(data)
     const token = this.createToken("fence", "code", 0, {
@@ -68,7 +68,7 @@ export class CodeBlock extends Directive {
     name: unchanged,
     class: class_option
   }
-  run(data: IDirectiveData): Token[] {
+  run(data: IDirectiveData<keyof CodeBlock["option_spec"]>): Token[] {
     // TODO handle options
     this.assert_has_content(data)
     const token = this.createToken("fence", "code", 0, {
@@ -89,7 +89,7 @@ export class CodeCell extends Directive {
   public has_content = true
   public rawOptions = true
 
-  run(data: IDirectiveData): Token[] {
+  run(data: IDirectiveData<keyof CodeCell["option_spec"]>): Token[] {
     // TODO store options and the fact that this is a code cell rather than a fence?
     const token = this.createToken("fence", "code", 0, {
       info: data.args ? data.args[0] : "",

--- a/src/directives/images.ts
+++ b/src/directives/images.ts
@@ -38,7 +38,7 @@ export class Image extends Directive {
     ...shared_option_spec,
     align: create_choice(["left", "center", "right", "top", "middle", "bottom"])
   }
-  create_image(data: IDirectiveData): Token {
+  create_image(data: IDirectiveData<keyof Image["option_spec"]>): Token {
     // get URI
     const src = uri(data.args[0] || "")
 
@@ -89,7 +89,7 @@ export class Figure extends Image {
     figclass: class_option
   }
   public has_content = true
-  run(data: IDirectiveData): Token[] {
+  run(data: IDirectiveData<keyof Figure["option_spec"]>): Token[] {
     const openToken = this.createToken("figure_open", "figure", 1, { map: data.map })
     if (data.options.figclass) {
       openToken.attrJoin("class", data.options.figclass.join(" "))

--- a/src/directives/main.ts
+++ b/src/directives/main.ts
@@ -65,9 +65,7 @@ export interface IDirectiveSpec {
   /** if body content is allowed */
   has_content?: boolean
   /** mapping known option names to conversion functions */
-  option_spec?: {
-    [key: string]: OptionSpecConverter
-  }
+  option_spec?: Record<string, OptionSpecConverter>
   /** If true, do not attempt to validate/convert options. */
   rawOptions?: boolean
 }
@@ -153,10 +151,10 @@ export class Directive implements IDirectiveSpec {
 }
 
 /** Data structure of a directive */
-export interface IDirectiveData {
+export interface IDirectiveData<T extends string = string> {
   map: [number, number]
   args: string[]
-  options: { [key: string]: any }
+  options: Record<T, any>
   body: string
   bodyMap: [number, number]
 }

--- a/src/directives/math.ts
+++ b/src/directives/math.ts
@@ -1,0 +1,35 @@
+/** Admonitions to visualise programming codes */
+import type Token from "markdown-it/lib/token"
+import { Directive, IDirectiveData } from "./main"
+import { unchanged } from "./options"
+
+/** Math directive with a label
+ */
+export class Math extends Directive {
+  public required_arguments = 0
+  public optional_arguments = 0
+  public final_argument_whitespace = false
+  public has_content = true
+  public option_spec = {
+    label: unchanged
+  }
+  run(data: IDirectiveData<keyof Math["option_spec"]>): Token[] {
+    // TODO handle options
+    this.assert_has_content(data)
+    const token = this.createToken("math_block", "div", 0, {
+      content: data.body,
+      map: data.bodyMap,
+      block: true
+    })
+    token.attrSet("class", "math block")
+    if (data.options.label) {
+      token.info = data.options.label
+      token.meta = { label: data.options.label, numbered: true }
+    }
+    return [token]
+  }
+}
+
+export const math = {
+  math: Math
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import { roles } from "./roles/main"
 import { html } from "./roles/html"
 import rolePlugin from "./roles/plugin"
 import type { IOptions as IRoleOptions } from "./roles/types"
-import { math } from "./roles/math"
+import { math as mathRole } from "./roles/math"
+import { math as mathDriective } from "./directives/math"
 
 /** Allowed options for docutils plugin */
 export interface IOptions extends IDirectiveOptions, IRoleOptions {
@@ -22,8 +23,8 @@ const OptionDefaults: IOptions = {
   replaceFences: true,
   rolesAfter: "inline",
   directivesAfter: "block",
-  directives: { ...admonitions, ...images, ...code, ...tables },
-  roles: { ...roles, ...html, ...math }
+  directives: { ...admonitions, ...images, ...code, ...tables, ...mathDriective },
+  roles: { ...roles, ...html, ...mathRole }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { html } from "./roles/html"
 import rolePlugin from "./roles/plugin"
 import type { IOptions as IRoleOptions } from "./roles/types"
 import { math as mathRole } from "./roles/math"
-import { math as mathDriective } from "./directives/math"
+import { math as mathDirective } from "./directives/math"
 
 /** Allowed options for docutils plugin */
 export interface IOptions extends IDirectiveOptions, IRoleOptions {
@@ -23,7 +23,7 @@ const OptionDefaults: IOptions = {
   replaceFences: true,
   rolesAfter: "inline",
   directivesAfter: "block",
-  directives: { ...admonitions, ...images, ...code, ...tables, ...mathDriective },
+  directives: { ...admonitions, ...images, ...code, ...tables, ...mathDirective },
   roles: { ...roles, ...html, ...mathRole }
 }
 

--- a/tests/fixtures/directives.math.md
+++ b/tests/fixtures/directives.math.md
@@ -1,0 +1,23 @@
+math directive
+.
+```{math}
+w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
+```
+.
+<div class="math block">
+w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
+</div>
+.
+
+math directive with label
+.
+```{math}
+:label: my_label
+w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
+```
+.
+<div class="math block">
+w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
+</div>
+.
+


### PR DESCRIPTION
Introduce a math directive:

````
```{math}
:label: my_label
w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
```
````

Development:
* Better typing for options

Leaving out of this PR:
* Actually dealing with the labels