### PR TITLE
📚 DOCS: Improve demo with autorefresh & textarea autoresize

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -117,7 +117,7 @@ w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
       var renderer = document.getElementById("renderer")
 
       // setup change handler
-      inputText.onchange = handleChange
+      inputText.oninput = handleChange
       function handleChange(e) {
         const text = window
           .markdownit()
@@ -127,7 +127,7 @@ w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
       }
 
       // trigger change handler for first render
-      const event = new Event("change")
+      const event = new Event("input")
       inputText.dispatchEvent(event)
 
       // TODO add code syntax highlight function, see e.g. markdown-it/support/demo_template/index.js

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,7 @@
     <!-- <link rel="stylesheet" type="text/css" media="screen" href="../dist/css/style.min.css" /> -->
     <script src="https://cdn.jsdelivr.net/npm/markdown-it@12/dist/markdown-it.min.js"></script>
     <script src="https://unpkg.com/markdown-it-docutils"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/autosize.js/5.0.1/autosize.min.js"></script>
     <!-- <script src="../dist/umd/index.js"></script> -->
   </head>
   <body>
@@ -39,7 +40,7 @@
           >
           for details.
         </p>
-        <textarea id="inputtext" class="inputtext" rows="60">
+        <textarea id="inputtext" class="inputtext">
 Unhandled role: {unknown}`content` in paragraph.
 
 Raw role: {raw}`content`
@@ -126,9 +127,12 @@ w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
         renderer.innerHTML = text
       }
 
-      // trigger change handler for first render
-      const event = new Event("input")
-      inputText.dispatchEvent(event)
+      window.addEventListener("load", function(event) {
+        // resize input textarea
+        autosize(document.querySelectorAll('#inputtext'))
+        // trigger change handler for first render
+        inputText.dispatchEvent(new Event("input"))
+      })
 
       // TODO add code syntax highlight function, see e.g. markdown-it/support/demo_template/index.js
     </script>


### PR DESCRIPTION
This should make the demo a bit more compelling, as having to click away scroll in the text area is not ideal.

Feel free to discard my commit messages when squash-merging this.