### PR TITLE
Fix: export css styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     ".": {
       "require": "./dist/umd/index.js",
       "import": "./dist/mjs/index.js"
-    }
+    },
+    "./dist/css/": "./dist/css/"
   },
   "scripts": {
     "format": "prettier --write src/**/*.ts tests/**/*.ts src/**/*.scss",


### PR DESCRIPTION
The current default exports prevent the `enhanced-resolve` resolver from finding the CSS files (see the error [here](https://github.com/executablebooks/jupyterlab-myst/runs/4882964268?check_suite_focus=true))

I'm not an expert - there may be a better way to default out, but I've just whitelisted the css dir for this PR.