### PR TITLE
every admonition should accept optional title

### DIFF
--- a/src/directives/admonitions.ts
+++ b/src/directives/admonitions.ts
@@ -10,6 +10,7 @@ import { Directive, IDirectiveData } from "./main"
  * Apdapted from: docutils/docutils/parsers/rst/directives/admonitions.py
  */
 class BaseAdmonition extends Directive {
+  public optional_arguments = 1
   public final_argument_whitespace = true
   public has_content = true
   public option_spec = {


### PR DESCRIPTION
Recent experiences with [myst-vs-code](https://github.com/executablebooks/myst-vs-code) have taught me this is necessary. Otherwise, for example, your notes are titled "Note" even though you have written

    :::{note} AnythingButNote
    asdf
    ::::

One doubt -- does `optional_arguments` need to be set back to zero for the plain `Admonition` where `required_arguments = 1`?
