### PR TITLE
[FIX] admon titles can be longer than one word

### DIFF
--- a/src/directives/admonitions.ts
+++ b/src/directives/admonitions.ts
@@ -46,7 +46,7 @@ class BaseAdmonition extends Directive {
     newTokens.push(adTokenTitle)
 
     // we want the title to be parsed as Markdown during the inline phase
-    const title = data.args[0] || this.title
+    const title = data.args.join(' ') || this.title
     newTokens.push(
       this.createToken("inline", "", 0, {
         map: [data.map[0], data.map[0]],

--- a/src/directives/admonitions.ts
+++ b/src/directives/admonitions.ts
@@ -46,7 +46,7 @@ class BaseAdmonition extends Directive {
     newTokens.push(adTokenTitle)
 
     // we want the title to be parsed as Markdown during the inline phase
-    const title = data.args.join(' ') || this.title
+    const title = data.args.join(" ") || this.title
     newTokens.push(
       this.createToken("inline", "", 0, {
         map: [data.map[0], data.map[0]],


### PR DESCRIPTION
This fixes truncation of the title after the 1st word:

    ::: {admonition} My title
    Hello
    :::

![image](https://user-images.githubusercontent.com/7685034/222996597-9d8a8841-48f3-49e3-86c8-50e77445b4c6.png)
